### PR TITLE
制限時間の開始を全員が揃った後にした

### DIFF
--- a/lib/page/chat/component/receive_message_bubble.dart
+++ b/lib/page/chat/component/receive_message_bubble.dart
@@ -6,13 +6,14 @@ import 'package:wordwolf/provider/presentation_providers.dart';
 import 'package:wordwolf/constant/text_style_constant.dart';
 
 class ReceiveMessageBubble extends ConsumerWidget {
-  ReceiveMessageBubble({
+  const ReceiveMessageBubble({
     Key? key,
     required this.messageEntity,
     required this.roomId,
   }) : super(key: key);
   final MessageEntity messageEntity;
   final String roomId;
+
   Size _textSize(String text) {
     final TextPainter textPainter = TextPainter(
         text: TextSpan(text: text),
@@ -57,7 +58,10 @@ class ReceiveMessageBubble extends ConsumerWidget {
           members.when(
             data: (data) {
               return Text(
-                data[messageEntity.userId]!.toString(),
+                /// Todo nullになぜなるか
+                data[messageEntity.userId] == null
+                    ? ''
+                    : data[messageEntity.userId]!.toString(),
                 style: const TextStyle(fontSize: 32),
               );
             },

--- a/lib/page/chat/component/theme_dialog.dart
+++ b/lib/page/chat/component/theme_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:wordwolf/constant/color_constant.dart';
 import 'package:wordwolf/constant/text_style_constant.dart';
 import 'package:wordwolf/provider/presentation_providers.dart';
@@ -31,6 +32,12 @@ class _ThemeDialogState extends ConsumerState<ThemeDialog> {
         child: Center(
           child: messages.when(
             data: (data) {
+              if (data.length == widget.maxNum) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  ref.read(limitTimeProvider.notifier).startTimer();
+                });
+                context.pop();
+              }
               return Column(
                 children: [
                   const Text('あなたは', style: TextStyleConstant.normal16),

--- a/lib/provider/presentation_providers.dart
+++ b/lib/provider/presentation_providers.dart
@@ -1,6 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:wordwolf/repository/message_repository.dart';
 import 'package:wordwolf/repository/room_repository.dart';
+
+part 'presentation_providers.g.dart';
 
 final messageTextFieldProvider = StateProvider<String>((ref) => '');
 
@@ -25,3 +30,17 @@ final membersStreamProvider = StreamProvider.family(
 final answerRadioValueProvider = StateProvider<String>((ref) => '');
 
 final maxMemberProvider = StateProvider<int>((ref) => 3);
+
+@riverpod
+class LimitTime extends _$LimitTime {
+  @override
+  int build() {
+    return 90;
+  }
+
+  void startTimer() {
+    Timer.periodic(Duration(seconds: 1), (timer) {
+      state = state - 1;
+    });
+  }
+}

--- a/lib/provider/presentation_providers.g.dart
+++ b/lib/provider/presentation_providers.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'presentation_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$limitTimeHash() => r'20a5224637ffd9ae3a26407e1256c5869216c580';
+
+/// See also [LimitTime].
+@ProviderFor(LimitTime)
+final limitTimeProvider = AutoDisposeNotifierProvider<LimitTime, int>.internal(
+  LimitTime.new,
+  name: r'limitTimeProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$limitTimeHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$LimitTime = AutoDisposeNotifier<int>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions


### PR DESCRIPTION
## 概要
close #54 
TimerをChatPageのinitStateからRiverpodのProviderに移し、全員が揃った(messsageの数とmaxNumの数が一致)したときにタイマーを開始するようにした。
- limitTimeProviderの作成
- タイマーが始まるまでチャット非表示