### PR TITLE
apiを修正し、ユーザーの質問にgptが答えるようにした

### DIFF
--- a/lib/data/api/gpt_api.dart
+++ b/lib/data/api/gpt_api.dart
@@ -17,6 +17,9 @@ abstract class RestClient {
 
   @POST('/make_topic_answer')
   Future<Message> fetchTopicAnswerMessage(@Body() Topic topic);
+
+  @POST('/make_question_answer')
+  Future<Message> fetchQuestionAnswerMessage(@Body() Message message);
 }
 
 @JsonSerializable()

--- a/lib/data/api/gpt_api.dart
+++ b/lib/data/api/gpt_api.dart
@@ -8,15 +8,15 @@ part 'gpt_api.g.dart';
 
 final apiClientProvider = Provider((ref) => RestClient(Dio()));
 
-@RestApi()
+@RestApi(baseUrl: "https://asia-northeast1-wordwolf-1f53d.cloudfunctions.net/")
 abstract class RestClient {
   factory RestClient(Dio dio, {String baseUrl}) = _RestClient;
 
   @GET("/messages")
   Future<List<MessageDocument>> getMessages();
 
-  @POST("https://wordwolf-5uxbsy4xrq-an.a.run.app")
-  Future<Message> fetchMessage(@Body() Topic topic);
+  @POST('/make_topic_answer')
+  Future<Message> fetchTopicAnswerMessage(@Body() Topic topic);
 }
 
 @JsonSerializable()

--- a/lib/data/api/gpt_api.dart
+++ b/lib/data/api/gpt_api.dart
@@ -24,10 +24,11 @@ abstract class RestClient {
 
 @JsonSerializable()
 class Message {
+  String? topic;
   String content;
   String userId;
 
-  Message({required this.content, required this.userId});
+  Message({required this.topic, required this.content, required this.userId});
 
   factory Message.fromJson(Map<String, dynamic> json) => _$MessageFromJson(json);
   Map<String, dynamic> toJson() => _$MessageToJson(this);

--- a/lib/data/api/gpt_api.g.dart
+++ b/lib/data/api/gpt_api.g.dart
@@ -34,7 +34,9 @@ class _RestClient implements RestClient {
   _RestClient(
     this._dio, {
     this.baseUrl,
-  });
+  }) {
+    baseUrl ??= 'https://asia-northeast1-wordwolf-1f53d.cloudfunctions.net/';
+  }
 
   final Dio _dio;
 
@@ -81,6 +83,54 @@ class _RestClient implements RestClient {
             .compose(
               _dio.options,
               'https://wordwolf-5uxbsy4xrq-an.a.run.app',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = Message.fromJson(_result.data!);
+    return value;
+  }
+
+  @override
+  Future<Message> fetchTopicAnswerMessage(Topic topic) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(topic.toJson());
+    final _result =
+        await _dio.fetch<Map<String, dynamic>>(_setStreamType<Message>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/make_topic_answer',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = Message.fromJson(_result.data!);
+    return value;
+  }
+
+  @override
+  Future<Message> fetchQuestionAnswerMessage(Message message) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(message.toJson());
+    final _result =
+        await _dio.fetch<Map<String, dynamic>>(_setStreamType<Message>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/make_question_answer',
               queryParameters: queryParameters,
               data: _data,
             )

--- a/lib/data/api/gpt_api.g.dart
+++ b/lib/data/api/gpt_api.g.dart
@@ -7,11 +7,13 @@ part of 'gpt_api.dart';
 // **************************************************************************
 
 Message _$MessageFromJson(Map<String, dynamic> json) => Message(
+      topic: json['topic'] as String?,
       content: json['content'] as String,
       userId: json['userId'] as String,
     );
 
 Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
+      'topic': instance.topic,
       'content': instance.content,
       'userId': instance.userId,
     };
@@ -64,30 +66,6 @@ class _RestClient implements RestClient {
     var value = _result.data!
         .map((dynamic i) => MessageDocument.fromJson(i as Map<String, dynamic>))
         .toList();
-    return value;
-  }
-
-  @override
-  Future<Message> fetchMessage(Topic topic) async {
-    const _extra = <String, dynamic>{};
-    final queryParameters = <String, dynamic>{};
-    final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{};
-    _data.addAll(topic.toJson());
-    final _result =
-        await _dio.fetch<Map<String, dynamic>>(_setStreamType<Message>(Options(
-      method: 'POST',
-      headers: _headers,
-      extra: _extra,
-    )
-            .compose(
-              _dio.options,
-              'https://wordwolf-5uxbsy4xrq-an.a.run.app',
-              queryParameters: queryParameters,
-              data: _data,
-            )
-            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    final value = Message.fromJson(_result.data!);
     return value;
   }
 

--- a/lib/data/api_data_source.dart
+++ b/lib/data/api_data_source.dart
@@ -12,13 +12,13 @@ class ApiDataSource {
   /// Message
   ///
 
-  Future<Message> fetchMessage(String topic) async {
+  Future<Message> fetchTopicAnswerMessage(String topic) async {
     try {
       final api = ref.read(apiClientProvider);
-      final message = await api.fetchMessage(Topic(topic: topic));
+      final message = await api.fetchTopicAnswerMessage(Topic(topic: topic));
       return message;
     } catch (e) {
-      print('api_getMessage');
+      print('api_getMessageWithPrompt');
       throw e;
     }
   }

--- a/lib/data/api_data_source.dart
+++ b/lib/data/api_data_source.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wordwolf/data/api/gpt_api.dart';
+import 'package:wordwolf/entity/message/message_entity.dart';
 
 final apiProvider = Provider<ApiDataSource>((ref) => ApiDataSource(ref: ref));
 
@@ -17,6 +18,27 @@ class ApiDataSource {
       final api = ref.read(apiClientProvider);
       final message = await api.fetchTopicAnswerMessage(Topic(topic: topic));
       return message;
+    } catch (e) {
+      print('api_getMessageWithPrompt');
+      throw e;
+    }
+  }
+
+  Future<Message> fetchQuestionAnswerMessage(
+    MessageEntity message,
+    String topic,
+  ) async {
+    try {
+      final api = ref.read(apiClientProvider);
+      final resMessage = await api.fetchQuestionAnswerMessage(
+        Message(
+          topic: topic,
+          content: message.content,
+          userId: message.userId,
+        ),
+      );
+      print(resMessage.content);
+      return resMessage;
     } catch (e) {
       print('api_getMessageWithPrompt');
       throw e;

--- a/lib/page/chat/chat_page.dart
+++ b/lib/page/chat/chat_page.dart
@@ -23,7 +23,6 @@ class ChatPage extends ConsumerStatefulWidget {
 }
 
 class _ChatPageState extends ConsumerState<ChatPage> {
-  final topic = "うどん";
   int maxNum = 100;
   bool isDialog = false;
 
@@ -41,6 +40,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   @override
   void initState() {
+    final topic = ref.read(topicProvider);
     ref.read(messageRepositoryProvider).addMessageFromGptToTopic(topic, widget.roomId);
     super.initState();
     WidgetsBinding.instance!.addPostFrameCallback((_) => _showStartDialog());
@@ -48,6 +48,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   @override
   Widget build(BuildContext context) {
+    final topic = ref.watch(topicProvider);
     final messages = ref.watch(messagesStreamProvider(widget.roomId));
     final counter = ref.watch(limitTimeProvider);
     final uid = ref.watch(uidProvider);
@@ -71,7 +72,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
           centerTitle: true,
           title: Row(
             children: [
-              Text("お題はうどん",
+              Text("お題は$topic",
                   style: TextStyleConstant.bold16.copyWith(
                     color: ColorConstant.black100,
                   )),

--- a/lib/page/chat/chat_page.dart
+++ b/lib/page/chat/chat_page.dart
@@ -40,7 +40,7 @@ class _ChatPageState extends ConsumerState<ChatPage> {
 
   @override
   void initState() {
-    ref.read(messageRepositoryProvider).addMessageFromGpt(topic, widget.roomId);
+    ref.read(messageRepositoryProvider).addMessageFromGptToTopic(topic, widget.roomId);
     super.initState();
     WidgetsBinding.instance!.addPostFrameCallback((_) => _showStartDialog());
   }

--- a/lib/page/chat/component/theme_dialog.dart
+++ b/lib/page/chat/component/theme_dialog.dart
@@ -21,6 +21,7 @@ class _ThemeDialogState extends ConsumerState<ThemeDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final topic = ref.watch(topicProvider);
     final messages = ref.watch(messagesStreamProvider(widget.roomId));
     final members = ref.watch(membersStreamProvider(widget.roomId));
     final uid = ref.watch(uidProvider);
@@ -60,13 +61,13 @@ class _ThemeDialogState extends ConsumerState<ThemeDialog> {
                           style: TextStyleConstant.bold24,
                         ),
                         const SizedBox(height: 16),
-                        const Row(
+                        Row(
                           children: [
-                            Spacer(),
-                            Text('お題', style: TextStyleConstant.normal18),
-                            Spacer(),
-                            Text('うどん', style: TextStyleConstant.bold28),
-                            Spacer(),
+                            const Spacer(),
+                            const Text('お題', style: TextStyleConstant.normal18),
+                            const Spacer(),
+                            Text(topic, style: TextStyleConstant.bold28),
+                            const Spacer(),
                           ],
                         ),
                         const SizedBox(height: 32),

--- a/lib/provider/presentation_providers.dart
+++ b/lib/provider/presentation_providers.dart
@@ -31,6 +31,8 @@ final answerRadioValueProvider = StateProvider<String>((ref) => '');
 
 final maxMemberProvider = StateProvider<int>((ref) => 3);
 
+final topicProvider = StateProvider((ref) => 'うどん');
+
 @riverpod
 class LimitTime extends _$LimitTime {
   @override

--- a/lib/repository/message_repository.dart
+++ b/lib/repository/message_repository.dart
@@ -21,10 +21,11 @@ class MessageRepository {
     await firestore.insertMessage(messageDoc, roomId);
   }
 
-  Future<void> addMessageFromGpt(String topic, String roomId) async {
+  /// topicに対するAIの返答
+  Future<void> addMessageFromGptToTopic(String topic, String roomId) async {
     final api = ref.read(apiProvider);
     final firestore = ref.read(firestoreProvider);
-    final message = await api.fetchMessage(topic);
+    final message = await api.fetchTopicAnswerMessage(topic);
     final entity = MessageEntity(content: message.content, userId: message.userId, createdAt: DateTime.now());
     final messageDoc = entity.toMessageDocument();
     await firestore.insertMessage(messageDoc, roomId); 

--- a/lib/repository/message_repository.dart
+++ b/lib/repository/message_repository.dart
@@ -12,13 +12,15 @@ class MessageRepository {
 
   final Ref ref;
 
-  /// 新規タスク追加
+  /// 新規メッセージ追加
   Future<void> addMessage(String content, String roomId) async {
     final firestore = ref.read(firestoreProvider);
     final uid = ref.read(uidProvider);
-    final entity = MessageEntity(content: content, userId: uid, createdAt: DateTime.now());
+    final entity =
+        MessageEntity(content: content, userId: uid, createdAt: DateTime.now());
     final messageDoc = entity.toMessageDocument();
     await firestore.insertMessage(messageDoc, roomId);
+    addMessageFromGptToQuestion(entity, roomId);
   }
 
   /// topicに対するAIの返答
@@ -26,9 +28,33 @@ class MessageRepository {
     final api = ref.read(apiProvider);
     final firestore = ref.read(firestoreProvider);
     final message = await api.fetchTopicAnswerMessage(topic);
-    final entity = MessageEntity(content: message.content, userId: message.userId, createdAt: DateTime.now());
+    final entity = MessageEntity(
+        content: message.content,
+        userId: message.userId,
+        createdAt: DateTime.now());
     final messageDoc = entity.toMessageDocument();
-    await firestore.insertMessage(messageDoc, roomId); 
+    await firestore.insertMessage(messageDoc, roomId);
+  }
+
+  /// 他のユーザーが疑問文で送ったときに対するAIの返答
+  Future<void> addMessageFromGptToQuestion(
+      MessageEntity message, String roomId) async {
+    print('send_api');
+    final api = ref.read(apiProvider);
+    final firestore = ref.read(firestoreProvider);
+    final topic = ref.read(topicProvider);
+    final resMessage = await api.fetchQuestionAnswerMessage(message, topic);
+    final resEntity = MessageEntity(
+      content: resMessage.content,
+      userId: resMessage.userId,
+      createdAt: DateTime.now(),
+    );
+    // 疑問文でない場合何も保存しない
+    if (resEntity.content == '') {
+      return;
+    }
+    final messageDoc = resEntity.toMessageDocument();
+    await firestore.insertMessage(messageDoc, roomId);
   }
 
   /// タスクのストリームを取得


### PR DESCRIPTION
## 概要
/make_question_answerのapiを追加し、メッセージの中に疑問文がある場合gptが回答を送るようにした。
回答を作成する際にtopicもapiに送る必要があったのでproviderで状態管理するようにした。

### ついにcloud functionsがroute管理できるドメインになった！！