### PR TITLE
ルームメンバーの保存方法を変更した

### DIFF
--- a/lib/data/firestore_data_source.dart
+++ b/lib/data/firestore_data_source.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wordwolf/document/member/member_document.dart';
 import 'package:wordwolf/document/message/message_document.dart';
 import 'package:wordwolf/document/room/room_document.dart';
 import 'package:wordwolf/provider/domain_providers.dart';
@@ -47,14 +48,16 @@ class FirestoreDataSource {
   Future<void> createRoom(RoomDocument roomDocument) async {
     final db = ref.read(firebaseFirestoreProvider);
     final collection = db.collection('rooms');
-    await collection.doc(roomDocument.id).set(roomDocument.copyWith.call().toJson());
+    await collection
+        .doc(roomDocument.id)
+        .set(roomDocument.copyWith.call().toJson());
   }
 
   /// ルームに参加
-  Future<void> addMemberToRoom(String roomId, String userId) async {
+  Future<void> addMemberToRoom(String roomId, MemberDocument member) async {
     final db = ref.read(firebaseFirestoreProvider);
     final collection = db.collection('rooms/$roomId/members');
-    await collection.doc(userId).set({'userId': userId});
+    await collection.doc(member.userId).set(member.copyWith.call().toJson());
   }
 
   /// ルームを取得
@@ -100,6 +103,21 @@ class FirestoreDataSource {
   }
 
   ///Member
+
+  /// メンバーのストリームを取得
+  Stream<List<MemberDocument>> fetchMembersStream(String roomId) {
+    try {
+      final db = ref.read(firebaseFirestoreProvider);
+      final stream = db.collection('rooms/$roomId/members').snapshots();
+      return stream.map((event) => event.docs
+          .map((doc) => doc.data())
+          .map((data) => MemberDocument.fromJson(data))
+          .toList());
+    } catch (e) {
+      print('firestore_getMemberStream');
+      throw e;
+    }
+  }
 
   /// メンバーの取得
   Future<List<String>> fetchMembers(String roomId) async {

--- a/lib/document/member/member_document.dart
+++ b/lib/document/member/member_document.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'member_document.freezed.dart';
+
+part 'member_document.g.dart';
+
+@freezed
+class MemberDocument with _$MemberDocument {
+  const MemberDocument._();
+
+  const factory MemberDocument({
+    @JsonKey(name: 'userId') required String userId,
+    @JsonKey(name: 'assignedId') required int assignedId,
+  }) = _MemberDocument;
+
+  factory MemberDocument.fromJson(Map<String, dynamic> json) =>
+      _$MemberDocumentFromJson(json);
+}

--- a/lib/document/member/member_document.freezed.dart
+++ b/lib/document/member/member_document.freezed.dart
@@ -1,0 +1,185 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'member_document.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+MemberDocument _$MemberDocumentFromJson(Map<String, dynamic> json) {
+  return _MemberDocument.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MemberDocument {
+  @JsonKey(name: 'userId')
+  String get userId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'assignedId')
+  int get assignedId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MemberDocumentCopyWith<MemberDocument> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MemberDocumentCopyWith<$Res> {
+  factory $MemberDocumentCopyWith(
+          MemberDocument value, $Res Function(MemberDocument) then) =
+      _$MemberDocumentCopyWithImpl<$Res, MemberDocument>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'assignedId') int assignedId});
+}
+
+/// @nodoc
+class _$MemberDocumentCopyWithImpl<$Res, $Val extends MemberDocument>
+    implements $MemberDocumentCopyWith<$Res> {
+  _$MemberDocumentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? assignedId = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      assignedId: null == assignedId
+          ? _value.assignedId
+          : assignedId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_MemberDocumentCopyWith<$Res>
+    implements $MemberDocumentCopyWith<$Res> {
+  factory _$$_MemberDocumentCopyWith(
+          _$_MemberDocument value, $Res Function(_$_MemberDocument) then) =
+      __$$_MemberDocumentCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'assignedId') int assignedId});
+}
+
+/// @nodoc
+class __$$_MemberDocumentCopyWithImpl<$Res>
+    extends _$MemberDocumentCopyWithImpl<$Res, _$_MemberDocument>
+    implements _$$_MemberDocumentCopyWith<$Res> {
+  __$$_MemberDocumentCopyWithImpl(
+      _$_MemberDocument _value, $Res Function(_$_MemberDocument) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? assignedId = null,
+  }) {
+    return _then(_$_MemberDocument(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      assignedId: null == assignedId
+          ? _value.assignedId
+          : assignedId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_MemberDocument extends _MemberDocument {
+  const _$_MemberDocument(
+      {@JsonKey(name: 'userId') required this.userId,
+      @JsonKey(name: 'assignedId') required this.assignedId})
+      : super._();
+
+  factory _$_MemberDocument.fromJson(Map<String, dynamic> json) =>
+      _$$_MemberDocumentFromJson(json);
+
+  @override
+  @JsonKey(name: 'userId')
+  final String userId;
+  @override
+  @JsonKey(name: 'assignedId')
+  final int assignedId;
+
+  @override
+  String toString() {
+    return 'MemberDocument(userId: $userId, assignedId: $assignedId)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_MemberDocument &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.assignedId, assignedId) ||
+                other.assignedId == assignedId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, userId, assignedId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_MemberDocumentCopyWith<_$_MemberDocument> get copyWith =>
+      __$$_MemberDocumentCopyWithImpl<_$_MemberDocument>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_MemberDocumentToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MemberDocument extends MemberDocument {
+  const factory _MemberDocument(
+          {@JsonKey(name: 'userId') required final String userId,
+          @JsonKey(name: 'assignedId') required final int assignedId}) =
+      _$_MemberDocument;
+  const _MemberDocument._() : super._();
+
+  factory _MemberDocument.fromJson(Map<String, dynamic> json) =
+      _$_MemberDocument.fromJson;
+
+  @override
+  @JsonKey(name: 'userId')
+  String get userId;
+  @override
+  @JsonKey(name: 'assignedId')
+  int get assignedId;
+  @override
+  @JsonKey(ignore: true)
+  _$$_MemberDocumentCopyWith<_$_MemberDocument> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/document/member/member_document.g.dart
+++ b/lib/document/member/member_document.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'member_document.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_MemberDocument _$$_MemberDocumentFromJson(Map<String, dynamic> json) =>
+    _$_MemberDocument(
+      userId: json['userId'] as String,
+      assignedId: json['assignedId'] as int,
+    );
+
+Map<String, dynamic> _$$_MemberDocumentToJson(_$_MemberDocument instance) =>
+    <String, dynamic>{
+      'userId': instance.userId,
+      'assignedId': instance.assignedId,
+    };

--- a/lib/entity/member/member_entity.dart
+++ b/lib/entity/member/member_entity.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wordwolf/document/member/member_document.dart';
+
+part 'member_entity.freezed.dart';
+
+@freezed
+class MemberEntity with _$MemberEntity {
+  const MemberEntity._();
+
+  const factory MemberEntity({
+    required String userId,
+    required String assignedId,
+  }) = _MemberEntity;
+
+  static MemberEntity fromDoc(MemberDocument memberDoc) {
+    return MemberEntity(
+      userId: memberDoc.userId,
+      assignedId: memberDoc.assignedId.toString(),
+    );
+  }
+
+  MemberDocument toMemberDocument() {
+    return MemberDocument(
+      userId: userId,
+      assignedId: 0,
+    );
+  }
+}

--- a/lib/entity/member/member_entity.freezed.dart
+++ b/lib/entity/member/member_entity.freezed.dart
@@ -1,0 +1,153 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'member_entity.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$MemberEntity {
+  String get userId => throw _privateConstructorUsedError;
+  String get assignedId => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $MemberEntityCopyWith<MemberEntity> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MemberEntityCopyWith<$Res> {
+  factory $MemberEntityCopyWith(
+          MemberEntity value, $Res Function(MemberEntity) then) =
+      _$MemberEntityCopyWithImpl<$Res, MemberEntity>;
+  @useResult
+  $Res call({String userId, String assignedId});
+}
+
+/// @nodoc
+class _$MemberEntityCopyWithImpl<$Res, $Val extends MemberEntity>
+    implements $MemberEntityCopyWith<$Res> {
+  _$MemberEntityCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? assignedId = null,
+  }) {
+    return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      assignedId: null == assignedId
+          ? _value.assignedId
+          : assignedId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_MemberEntityCopyWith<$Res>
+    implements $MemberEntityCopyWith<$Res> {
+  factory _$$_MemberEntityCopyWith(
+          _$_MemberEntity value, $Res Function(_$_MemberEntity) then) =
+      __$$_MemberEntityCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String userId, String assignedId});
+}
+
+/// @nodoc
+class __$$_MemberEntityCopyWithImpl<$Res>
+    extends _$MemberEntityCopyWithImpl<$Res, _$_MemberEntity>
+    implements _$$_MemberEntityCopyWith<$Res> {
+  __$$_MemberEntityCopyWithImpl(
+      _$_MemberEntity _value, $Res Function(_$_MemberEntity) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? assignedId = null,
+  }) {
+    return _then(_$_MemberEntity(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      assignedId: null == assignedId
+          ? _value.assignedId
+          : assignedId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_MemberEntity extends _MemberEntity {
+  const _$_MemberEntity({required this.userId, required this.assignedId})
+      : super._();
+
+  @override
+  final String userId;
+  @override
+  final String assignedId;
+
+  @override
+  String toString() {
+    return 'MemberEntity(userId: $userId, assignedId: $assignedId)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_MemberEntity &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.assignedId, assignedId) ||
+                other.assignedId == assignedId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, userId, assignedId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_MemberEntityCopyWith<_$_MemberEntity> get copyWith =>
+      __$$_MemberEntityCopyWithImpl<_$_MemberEntity>(this, _$identity);
+}
+
+abstract class _MemberEntity extends MemberEntity {
+  const factory _MemberEntity(
+      {required final String userId,
+      required final String assignedId}) = _$_MemberEntity;
+  const _MemberEntity._() : super._();
+
+  @override
+  String get userId;
+  @override
+  String get assignedId;
+  @override
+  @JsonKey(ignore: true)
+  _$$_MemberEntityCopyWith<_$_MemberEntity> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/page/chat/component/answer_dialog.dart
+++ b/lib/page/chat/component/answer_dialog.dart
@@ -19,7 +19,6 @@ class AnswerDialog extends ConsumerWidget {
 
     return members.when(
       data: (data) {
-        final nameList = data.values.toList();
         return AlertDialog(
           backgroundColor: ColorConstant.black100,
           shape: const RoundedRectangleBorder(
@@ -31,13 +30,13 @@ class AnswerDialog extends ConsumerWidget {
             child: Column(
               children: [
                 const Text('誰がAI？'),
-                ...nameList
+                ...data
                     .map(
-                      (name) => ListTile(
-                        title: Text('プレイヤー${name.toString()}'),
+                      (member) => ListTile(
+                        title: Text('プレイヤー${member.assignedId}'),
                         leading: Radio<String>(
                           activeColor: ColorConstant.main,
-                          value: 'プレイヤー${name.toString()}',
+                          value: 'プレイヤー${member.assignedId}',
                           groupValue: value,
                           onChanged: (String? value) {
                             if (value != null) {
@@ -55,9 +54,10 @@ class AnswerDialog extends ConsumerWidget {
                     showDialog(
                       context: context,
                       builder: (_) {
+                        final gpt = data[data.indexWhere((e) => e.userId == 'gpt')];
                         return CorrectDialog(
-                          answerName: data['gpt'].toString(),
-                          isCorrect: value[value.length - 1] == data['gpt'].toString(),
+                          gptAssignedId: gpt.assignedId,
+                          isCorrect: value[value.length - 1] == gpt.assignedId,
                           roomId: roomId,
                         );
                       },

--- a/lib/page/chat/component/bottom_text_field.dart
+++ b/lib/page/chat/component/bottom_text_field.dart
@@ -40,14 +40,9 @@ class BottomTextField extends ConsumerWidget {
           children: [
             members.when(
               data: (data) {
-                if (data[uid] == null) {
-                  return const Text(
-                    'loading',
-                    style: TextStyleConstant.normal12,
-                  );
-                }
+                final member = data[data.indexWhere((e) => e.userId == uid)];
                 return Text(
-                  'あなたはユーザー${data[uid]}（一般人）',
+                  'あなたはユーザー${member.assignedId}（一般人）',
                   style: TextStyleConstant.bold12,
                 );
               },

--- a/lib/page/chat/component/correct_dialog.dart
+++ b/lib/page/chat/component/correct_dialog.dart
@@ -48,6 +48,7 @@ class CorrectDialog extends ConsumerWidget {
                 onPressed: () async {
                   await ref.read(roomRepositoryProvider).leaveRoom(roomId);
                   ref.read(isMakeRoomProvider.notifier).update((state) => false);
+                  ref.read(limitTimeProvider.notifier).reset();
                   context.push('/');
                 },
                 child: Text(

--- a/lib/page/chat/component/correct_dialog.dart
+++ b/lib/page/chat/component/correct_dialog.dart
@@ -9,12 +9,12 @@ import 'package:wordwolf/repository/room_repository.dart';
 class CorrectDialog extends ConsumerWidget {
   const CorrectDialog({
     super.key,
-    required this.answerName,
+    required this.gptAssignedId,
     required this.isCorrect,
     required this.roomId,
   });
 
-  final String answerName;
+  final String gptAssignedId;
   final bool isCorrect;
   final String roomId;
 
@@ -40,7 +40,7 @@ class CorrectDialog extends ConsumerWidget {
                 'AIは',
                 style: TextStyleConstant.normal24,
               ),
-              Text('プレイヤー$answerName', style: TextStyleConstant.normal24),
+              Text('プレイヤー$gptAssignedId', style: TextStyleConstant.normal24),
               const SizedBox(height: 24),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(

--- a/lib/page/chat/component/receive_message_bubble.dart
+++ b/lib/page/chat/component/receive_message_bubble.dart
@@ -72,6 +72,8 @@ class ReceiveMessageBubble extends ConsumerWidget {
       padding: const EdgeInsets.all(4.0),
       child: members.when(
         data: (data) {
+          final member =
+              data[data.indexWhere((e) => e.userId == messageEntity.userId)];
           return Row(
             children: [
               const SizedBox(width: 8),
@@ -80,14 +82,11 @@ class ReceiveMessageBubble extends ConsumerWidget {
                 width: 40,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: borderColor(data[messageEntity.userId] ?? 0),
+                  color: borderColor(int.parse(member.assignedId)),
                 ),
                 child: Center(
                   child: Text(
-                    /// Todo nullになぜなるか
-                    data[messageEntity.userId] == null
-                        ? ''
-                        : data[messageEntity.userId]!.toString(),
+                    member.assignedId,
                     style: TextStyleConstant.normal24,
                   ),
                 ),
@@ -105,7 +104,7 @@ class ReceiveMessageBubble extends ConsumerWidget {
                   borderRadius: BorderRadius.circular(24),
                   color: ColorConstant.black100,
                   border: Border.all(
-                    color: borderColor(data[messageEntity.userId] ?? 0),
+                    color: borderColor(int.parse(member.assignedId)),
                     width: 2,
                   ),
                 ),

--- a/lib/page/chat/component/theme_dialog.dart
+++ b/lib/page/chat/component/theme_dialog.dart
@@ -52,7 +52,8 @@ class _ThemeDialogState extends ConsumerState<ThemeDialog> {
                 }
                 return members.when(
                   data: (members) {
-                    if (members[uid] == null) {
+                    final member = members[members.indexWhere((e) => e.userId == uid)];
+                    if (member.assignedId == '0') {
                       return const Text(
                         '配役決め中です...',
                         style: TextStyleConstant.normal16,
@@ -63,7 +64,7 @@ class _ThemeDialogState extends ConsumerState<ThemeDialog> {
                         const Text('あなたは', style: TextStyleConstant.normal16),
                         const SizedBox(height: 8),
                         Text(
-                          'プレイヤー${members[uid]}(一般人)',
+                          'プレイヤー${member.assignedId}(一般人)',
                           style: TextStyleConstant.bold24,
                         ),
                         const SizedBox(height: 16),

--- a/lib/page/root/component/join_dialog.dart
+++ b/lib/page/root/component/join_dialog.dart
@@ -87,7 +87,7 @@ class JoinDialog extends ConsumerWidget {
                 }
                 final uuid = const Uuid().v4();
                 ref.read(uidProvider.notifier).update((state) => uuid);
-                ref.read(roomRepositoryProvider).joinRoom(textValue);
+                await ref.read(roomRepositoryProvider).joinRoom(textValue);
                 context.push("/chat", extra: textValue);
               },
               style: ElevatedButton.styleFrom(

--- a/lib/page/root/component/start_dialog.dart
+++ b/lib/page/root/component/start_dialog.dart
@@ -155,10 +155,10 @@ class StartDialog extends ConsumerWidget {
             height: 48,
             width: 120,
             child: ElevatedButton(
-              onPressed: () {
+              onPressed: () async {
                 final uuid = const Uuid().v4();
                 ref.read(uidProvider.notifier).update((state) => uuid);
-                ref.read(roomRepositoryProvider).makeRoom(roomId, value);
+                await ref.read(roomRepositoryProvider).makeRoom(roomId, value);
                 ref.read(roomRepositoryProvider).joinRoom(roomId);
                 ref.read(isMakeRoomProvider.notifier).update((state) => true);
                 context.push("/chat", extra: roomId);

--- a/lib/provider/presentation_providers.dart
+++ b/lib/provider/presentation_providers.dart
@@ -50,6 +50,9 @@ class LimitTime extends _$LimitTime {
   void startTimer() {
     Timer.periodic(Duration(seconds: 1), (timer) {
       state = state - 1;
+      if (state < 0) {
+        timer.cancel();
+      }
     });
   }
 }

--- a/lib/provider/presentation_providers.dart
+++ b/lib/provider/presentation_providers.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:wordwolf/entity/member/member_entity.dart';
 import 'package:wordwolf/repository/message_repository.dart';
 import 'package:wordwolf/repository/room_repository.dart';
 
@@ -22,7 +23,7 @@ final messagesStreamProvider = StreamProvider.family(
       ref.watch(messageRepositoryProvider).getMessageStream(roomId),
 );
 
-final membersStreamProvider = StreamProvider.family(
+final membersStreamProvider = StreamProvider.family<List<MemberEntity>, String>(
   (ref, String roomId) =>
       ref.watch(roomRepositoryProvider).getRoomMemberStream(roomId),
 );

--- a/lib/provider/presentation_providers.dart
+++ b/lib/provider/presentation_providers.dart
@@ -43,6 +43,10 @@ class LimitTime extends _$LimitTime {
     return 90;
   }
 
+  void reset() {
+    state = 90;
+  }
+
   void startTimer() {
     Timer.periodic(Duration(seconds: 1), (timer) {
       state = state - 1;


### PR DESCRIPTION
close #76
## 概要
ゲーム性を人狼に寄せるにあたって、メンバーに役職なども割り当てるので、サブコレクションですべてメンバーを管理するようにした。

## 内容
- member modelの作成
- firebase functionsの処理変更
- タイマーのキャンセル機能